### PR TITLE
Use rounding value of Moneys context

### DIFF
--- a/tests/test_fields_money.py
+++ b/tests/test_fields_money.py
@@ -156,6 +156,17 @@ class TestMoney:
     def test_total_cents(self, func, iv, cur, ov):
         assert func(fields.Money(iv, cur)) == ov
 
+    def test_total_cents_rounding(self):
+        money = fields.Money(decimal.Decimal('1.235'), 'RUB')
+        assert id(money._context) == id(fields.Money._context)
+        assert money.total_cents == 124
+
+        fields.Money._context.rounding = decimal.ROUND_DOWN
+        assert money.total_cents == 123
+
+        money._context.rounding = decimal.ROUND_HALF_UP
+        assert money.total_cents == 124
+
     @pytest.mark.parametrize('iv, ov', [
         ((1000, 'RUB'), fields.Money(10, 'RUB')),
         ((1000, 'JPY'), fields.Money(1000, 'JPY')),

--- a/yadm/fields/money/money.py
+++ b/yadm/fields/money/money.py
@@ -131,7 +131,7 @@ class Money:
         """
         precision = self.currency.precision
         precision_decimal = Decimal('1.' + '0' * precision)
-        quantized = self.value.quantize(precision_decimal, ROUND_UP)
+        quantized = self.value.quantize(precision_decimal, self._context.rounding)
         return int(quantized * 10 ** precision)
 
     def __abs__(self):
@@ -197,7 +197,7 @@ class Money:
     def __str__(self):
         precision = self.currency.precision
         precision_decimal = Decimal('1.' + '0' * precision)
-        quantized = self.value.quantize(precision_decimal, ROUND_UP)
+        quantized = self.value.quantize(precision_decimal, self._context.rounding)
         return '{} {}'.format(quantized, self._currency.string)
 
     def __repr__(self):


### PR DESCRIPTION
In some methods of Money, quantize() use hard-coded ROUND_UP value. Commit change this to use global context of Money class.