### PR TITLE
Add support multiplication of money by Decimal

### DIFF
--- a/tests/test_fields_money.py
+++ b/tests/test_fields_money.py
@@ -212,6 +212,19 @@ class TestMoney:
             with pytest.raises(ValueError):
                 fields.Money('10', 'RUB') / fields.Money('2', 'EUR')
 
+    @pytest.mark.parametrize('first, seccond, result', [
+        (fields.Money('5', 'RUB'), 2, fields.Money('10.00', 'RUB')),
+        (fields.Money('2', 'RUB'), decimal.Decimal('5.5'), fields.Money('11', 'RUB')),
+        (fields.Money('10', 'RUB'), decimal.Decimal('0.3'), fields.Money('3', 'RUB')),
+    ])
+    def test_mul(self, first, seccond, result):
+            assert first * seccond == result
+            assert isinstance(first / seccond, result.__class__)
+
+    def test_mul__error(self):
+            with pytest.raises(TypeError):
+                fields.Money('10', 'RUB') * 1.2
+
 
 class TestCurrencyStorage:
     @pytest.mark.parametrize('key, code, string, precision', [

--- a/tests/test_fields_money.py
+++ b/tests/test_fields_money.py
@@ -200,7 +200,9 @@ class TestMoney:
 
     @pytest.mark.parametrize('first, seccond, result', [
         (fields.Money('10', 'RUB'), fields.Money('2', 'RUB'), decimal.Decimal('5.00')),
+        (fields.Money('10', 'RUB'), fields.Money('0.5', 'RUB'), decimal.Decimal('20')),
         (fields.Money('2', 'RUB'), fields.Money('10', 'RUB'), decimal.Decimal('0.20')),
+        (fields.Money('2', 'RUB'), 10, fields.Money('0.20', 'RUB')),
     ])
     def test_truediv(self, first, seccond, result):
             assert first / seccond == result

--- a/yadm/fields/money/money.py
+++ b/yadm/fields/money/money.py
@@ -149,7 +149,7 @@ class Money:
         return Money(-self.value, self.currency)
 
     def __mul__(self, target):
-        if isinstance(target, int):
+        if isinstance(target, (int, Decimal)):
             return self.__class__(self.value * target, self.currency)
         else:
             return NotImplemented


### PR DESCRIPTION
No more hell with `Money('12.50', 'USD') / 10 * 3`
Now you can do this: `Money('12.50', 'USD') * Decimal('0.3')`