### PR TITLE
Add QuerySet support __bool__

### DIFF
--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -39,6 +39,15 @@ def test_len(qs):
     assert len(qs) == 4
 
 
+@pytest.mark.parametrize('additional_qs, result', [
+    ({}, True),
+    ({'i': {'$gte': 6}}, True),
+    ({'i': {'$gte': 1000}}, False),
+])
+def test_bool_(qs, additional_qs, result):
+    assert bool(qs.find(additional_qs)) is result
+
+
 @pytest.mark.parametrize('slice, result', [
     (slice(None, 2), [6, 7]),
     (slice(2, None), [8, 9]),

--- a/yadm/queryset.py
+++ b/yadm/queryset.py
@@ -324,6 +324,9 @@ class QuerySet(BaseQuerySet):
     def __contains__(self, document):
         return self.find_one(document.id) is not None
 
+    def __bool__(self):
+        return bool(self.find_one())
+
     def _get_one(self, index):
         return self._from_mongo_one(self._cursor[index])
 


### PR DESCRIPTION
For optimize executing bool(query_set) operations add support for QuerySet magic method __bool__ via bool of find_one.