### PR TITLE
Fix EnumStateField on creating with initial value

### DIFF
--- a/tests/test_fields_enum.py
+++ b/tests/test_fields_enum.py
@@ -88,3 +88,7 @@ class TestEnumStateField:
 
         doc.e = WordsEnum.a
         assert doc.e == WordsEnum.a
+
+    def test_initial_value(self):
+        doc = self.Doc(e=WordsEnum.a)
+        assert doc.e == WordsEnum.a

--- a/tests/test_fields_enum.py
+++ b/tests/test_fields_enum.py
@@ -3,7 +3,7 @@ from enum import Enum
 import pytest
 
 from yadm import fields
-from yadm.fields.enum import EnumStateSetError
+from yadm.fields.enum import EnumStateSetError, EnumStateInvalidInitial
 from yadm.documents import Document
 
 
@@ -92,3 +92,7 @@ class TestEnumStateField:
     def test_initial_value(self):
         doc = self.Doc(e=WordsEnum.a)
         assert doc.e == WordsEnum.a
+
+    def test_initial_value__raises(self):
+        with pytest.raises(EnumStateInvalidInitial):
+            doc = self.Doc(e=WordsEnum.b)

--- a/yadm/fields/enum.py
+++ b/yadm/fields/enum.py
@@ -54,8 +54,11 @@ class EnumStateField(EnumField):
         current_value = getattr(document, self.name, AttributeNotSet)
         new_value = super().prepare_value(document, value)
 
-        if (new_value != current_value and
-                new_value not in self.rules.get(current_value, [])):
+        if all([
+            current_value is not AttributeNotSet,
+            new_value != current_value,
+            new_value not in self.rules.get(current_value, []),
+        ]):
             raise EnumStateSetError(current_value, new_value)
 
         return new_value


### PR DESCRIPTION
YADM goes crazy on attempt to create Document with initial value in EnumStateField:

```yadm.fields.enum.EnumStateSetError: Not allowed in rules: <class 'yadm.markers.AttributeNotSet'> -> WordsEnum.a```

