### PR TITLE
Fix bug with lost item_field value when copy field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 # python setup.py sdist --formats=bztar
 
-version = '2.0.5'
+version = '2.0.6'
 description = 'Yet Another Document Mapper (ODM) for MongoDB'
 long_description = open('README.rst', 'rb').read().decode('utf8')
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -14,6 +14,15 @@ class Doc(Document):
     b = fields.BooleanField()
 
 
+class BaseDoc(Document):
+    __collection__ = 'testa'
+    l1 = fields.ListField(fields.ObjectIdField())
+
+
+class ChildDoc(BaseDoc):
+    l2 = fields.ListField(fields.ObjectIdField())
+
+
 @pytest.fixture
 def doc():
     return Doc()
@@ -143,3 +152,13 @@ def test_str():
     doc = Doc()
     assert str(doc)
     assert str(doc) == repr(doc)
+
+
+def test_inheritance_docs_with_list(db):
+    assert BaseDoc.__fields__['l1'].item_field is not None
+    assert ChildDoc.__fields__['l2'].item_field is not None
+    assert ChildDoc.__fields__['l1'].item_field is not None
+
+    doc = ChildDoc()
+    db.save(doc)
+    assert doc

--- a/yadm/fields/base.py
+++ b/yadm/fields/base.py
@@ -210,7 +210,10 @@ class Field:
     def copy(self):  # pragma: no cover
         """ Return copy of field.
         """
-        return self.__class__(smart_null=self.smart_null)
+        return self.__class__(
+            item_field=self.item_field,
+            smart_null=self.smart_null,
+        )
 
     def get_default(self, document):
         """ Return default value.


### PR DESCRIPTION
This code

```
class A(Document):
   __collection__ = 'a'

   l1 = fields.ListField(fields.ObjectIdField())


class B(A):
   l2 = fields.ListField(fields.ObjectIdField())


def test_bug(db):
   doc = create_fake(B, db)
   assert doc
```

failed like this

```
self = <ListField "B.l1">, document = B(5c7510dab182c7a77dc79f12), value = List([])

   @pass_null
   def to_mongo(self, document, value):
>       tm = self.item_field.to_mongo
E       AttributeError: 'NoneType' object has no attribute 'to_mongo'

yadm/fields/list.py:186: AttributeError
```
The problem is when in metaclass MetaDocument use `field.copy()` the method `copy()` copy only `smart_null` attribute of original field. 
The decision is copy also `item_field` attribute