### PR TITLE
Add support asyncio version of create_fake function

### DIFF
--- a/tests/tests_aio/conftest.py
+++ b/tests/tests_aio/conftest.py
@@ -1,24 +1,17 @@
-import asyncio
-
 import pytest
 import motor.motor_asyncio
 
 from yadm.aio.database import AioDatabase
 
 
-@pytest.fixture(scope='function')
-def loop():
-    return asyncio.get_event_loop()
-
-
-@pytest.fixture(scope='session')
-def client(request, mongo_args):
-    host, port, name = mongo_args
+@pytest.fixture()
+def client(mongo_args):
+    host, port, _ = mongo_args
     return motor.motor_asyncio.AsyncIOMotorClient(host=host, port=port)
 
 
-@pytest.yield_fixture(scope='function')
-def db(loop, client, mongo_args):
-    host, port, name = mongo_args
-    loop.run_until_complete(client.drop_database(name))
-    yield AioDatabase(client, name)
+@pytest.fixture()
+def db(event_loop, client, mongo_args):
+    _, _, name = mongo_args
+    event_loop.run_until_complete(client.drop_database(name))
+    return AioDatabase(client, name)

--- a/tests/tests_aio/test_aggregate.py
+++ b/tests/tests_aio/test_aggregate.py
@@ -4,7 +4,6 @@ import pytest
 
 from yadm import Document
 from yadm import fields
-# from yadm.aio.aggregation import AioAggregator
 
 
 class Doc(Document):
@@ -13,29 +12,24 @@ class Doc(Document):
 
 
 @pytest.fixture(scope='function')
-def docs(loop, db):
-    async def gen_docs():
-        async with db.bulk_write(Doc) as writer:
-            docs = []
-            for n in range(randint(10, 20)):
-                doc = Doc(i=randint(-666, 666))
-                await writer.insert_one(doc)
-                docs.append(doc)
+async def docs(db):
+    async with db.bulk_write(Doc) as writer:
+        docs = []
+        for n in range(randint(10, 20)):
+            doc = Doc(i=randint(-666, 666))
+            await writer.insert_one(doc)
+            docs.append(doc)
 
-        return docs
-
-    return loop.run_until_complete(gen_docs())
+    return docs
 
 
-def test_async_for(loop, db, docs):
-    async def test():
-        agg = db.aggregate(Doc).match(i={'$gt': 0}).project(n='$i')
-        count = 0
+@pytest.mark.asyncio
+async def test_async_for(db, docs):
+    agg = db.aggregate(Doc).match(i={'$gt': 0}).project(n='$i')
+    count = 0
 
-        async for item in agg:
-            assert item['n'] > 0
-            count += 1
+    async for item in agg:
+        assert item['n'] > 0
+        count += 1
 
-        assert count == len([d.i for d in docs if d.i > 0])
-
-    loop.run_until_complete(test())
+    assert count == len([d.i for d in docs if d.i > 0])

--- a/tests/tests_aio/test_bulk_writer.py
+++ b/tests/tests_aio/test_bulk_writer.py
@@ -12,49 +12,45 @@ class Doc(Document):
 
 
 @pytest.fixture(scope='function')
-def inserted(loop, db):
+async def inserted(db):
     documents = [Doc(i=i) for i in range(10)]
-    loop.run_until_complete(db.insert_many(documents))
+    await db.insert_many(documents)
     return documents
 
 
 @pytest.mark.parametrize('batch_size', [3, BATCH_SIZE])
-def test_insert_one(loop, db, batch_size):
-    async def test():
-        async with db.bulk_write(Doc, batch_size=batch_size) as writer:
-            for doc in (Doc(i=i) for i in range(10)):
-                await writer.insert_one(doc)
+@pytest.mark.asyncio
+async def test_insert_one(db, batch_size):
+    async with db.bulk_write(Doc, batch_size=batch_size) as writer:
+        for doc in (Doc(i=i) for i in range(10)):
+            await writer.insert_one(doc)
 
-        assert writer.result.inserted_count == 10
-        assert await db.db['testdocs'].count_documents({}) == 10
-
-    loop.run_until_complete(test())
+    assert writer.result.inserted_count == 10
+    assert await db.db['testdocs'].count_documents({}) == 10
 
 
 @pytest.mark.parametrize('batch_size', [3, BATCH_SIZE])
-def test_complex(loop, db, inserted, batch_size):
-    async def test():
-        async with db.bulk_write(Doc, batch_size=batch_size) as writer:
-            for doc in (Doc(i=i) for i in range(10, 20)):
-                await writer.insert_one(doc)
+@pytest.mark.asyncio
+async def test_complex(db, inserted, batch_size):
+    async with db.bulk_write(Doc, batch_size=batch_size) as writer:
+        for doc in (Doc(i=i) for i in range(10, 20)):
+            await writer.insert_one(doc)
 
-            await writer.update_one({'i': 6}, {'$set': {'i': 66}})
-            await writer.update_many({'i': {'$gte': 18}}, {'$inc': {'i': 1}})
-            await writer.replace_one({'i': 3}, Doc(i=33))
-            await writer.delete_one({'i': 2})
-            await writer.delete_many({'i': {'$gte': 9, '$lt': 13}})
+        await writer.update_one({'i': 6}, {'$set': {'i': 66}})
+        await writer.update_many({'i': {'$gte': 18}}, {'$inc': {'i': 1}})
+        await writer.replace_one({'i': 3}, Doc(i=33))
+        await writer.delete_one({'i': 2})
+        await writer.delete_many({'i': {'$gte': 9, '$lt': 13}})
 
-            doc = inserted[7]
-            doc.i == 77
-            await writer.replace(doc)
+        doc = inserted[7]
+        doc.i == 77
+        await writer.replace(doc)
 
-            await writer.delete(inserted[8])
+        await writer.delete(inserted[8])
 
-        assert writer.result.inserted_count == 10
-        assert writer.result.deleted_count == 6
-        assert writer.result.modified_count == 6
-        assert writer.result.upserted_count == 0
+    assert writer.result.inserted_count == 10
+    assert writer.result.deleted_count == 6
+    assert writer.result.modified_count == 6
+    assert writer.result.upserted_count == 0
 
-        assert await db.db['testdocs'].count_documents({}) == 14
-
-    loop.run_until_complete(test())
+    assert await db.db['testdocs'].count_documents({}) == 14

--- a/tests/tests_aio/test_database.py
+++ b/tests/tests_aio/test_database.py
@@ -14,114 +14,102 @@ class Doc(Document):
     __collection__ = 'testdocs'
     b = fields.BooleanField()
     i = fields.IntegerField()
-    l = fields.ListField(fields.IntegerField())
+    l = fields.ListField(fields.IntegerField())  # noqa: E741
 
 
-def test_estimated_document_count(db):
-    async def test():
-        col = db.db['testdocs']
-        ids = []
-        for i in range(10):
-            ids.append(col.insert_one({'i': i}).inserted_id)
+@pytest.mark.asyncio
+async def test_estimated_document_count(db):
+    col = db.db['testdocs']
+    ids = []
+    for i in range(10):
+        ids.append((await col.insert_one({'i': i})).inserted_id)
 
-        count = await db.estimated_document_count(Doc)
-        assert count == len(ids) == 10
-
-
-def test_insert_one(loop, db):
-    async def test():
-        doc = Doc()
-        doc.i = 13
-
-        await db.insert_one(doc)
-
-        assert await db.db['testdocs'].count_documents({}) == 1
-        assert (await db.db['testdocs'].find_one())['i'] == 13
-        assert isinstance(doc.id, ObjectId)
-        assert Insert(id=doc.id) in doc.__log__
-        assert doc.__db__ is db
-
-    loop.run_until_complete(test())
+    count = await db.estimated_document_count(Doc)
+    assert count == len(ids) == 10
 
 
-def test_insert_many(loop, db):
-    async def test():
-        documents = [Doc(i=i) for i in range(10)]
-        random.shuffle(documents)
+@pytest.mark.asyncio
+async def test_insert_one(db):
+    doc = Doc()
+    doc.i = 13
 
-        result = await db.insert_many(documents)
+    await db.insert_one(doc)
 
-        for _id, doc in zip(result.inserted_ids, documents):
-            assert doc.id == _id
-
-        assert len(result.inserted_ids) == len(documents)
-
-    loop.run_until_complete(test())
-
-
-def test_insert_many__empty(loop, db):
-    async def test():
-        result = await db.insert_many([])
-        assert len(result.inserted_ids) == 0
-
-    loop.run_until_complete(test())
+    assert await db.db['testdocs'].count_documents({}) == 1
+    assert (await db.db['testdocs'].find_one())['i'] == 13
+    assert isinstance(doc.id, ObjectId)
+    assert Insert(id=doc.id) in doc.__log__
+    assert doc.__db__ is db
 
 
-def test_insert_many__unordered(loop, db):
-    async def test():
-        documents = [Doc(i=i) for i in range(10)]
-        random.shuffle(documents)
+@pytest.mark.asyncio
+async def test_insert_many(db):
+    documents = [Doc(i=i) for i in range(10)]
+    random.shuffle(documents)
 
-        result = await db.insert_many(documents, ordered=False)
+    result = await db.insert_many(documents)
 
-        for doc in documents:
-            assert not hasattr(doc, 'id')
+    for _id, doc in zip(result.inserted_ids, documents):
+        assert doc.id == _id
 
-        assert len(result.inserted_ids) == len(documents)
-
-    loop.run_until_complete(test())
+    assert len(result.inserted_ids) == len(documents)
 
 
-def test_save_new(loop, db):
-    async def test():
-        doc = Doc()
-        doc.i = 13
-
-        await db.save(doc)
-
-        assert await db.db['testdocs'].count_documents({}) == 1
-        assert (await db.db['testdocs'].find_one())['i'] == 13
-        assert Save(id=doc.id) in doc.__log__
-        assert doc.__db__ is db
-
-    loop.run_until_complete(test())
+@pytest.mark.asyncio
+async def test_insert_many__empty(db):
+    result = await db.insert_many([])
+    assert len(result.inserted_ids) == 0
 
 
-def test_save(loop, db):
-    async def test():
-        doc = Doc()
-        doc.i = 13
-        await db.save(doc)
+@pytest.mark.asyncio
+async def test_insert_many__unordered(db):
+    documents = [Doc(i=i) for i in range(10)]
+    random.shuffle(documents)
 
-        doc.i = 14
-        await db.save(doc)
+    result = await db.insert_many(documents, ordered=False)
 
-        assert await db.db['testdocs'].count_documents({}) == 1
-        assert (await db.db['testdocs'].find_one())['i'] == 14
-        assert Save(id=doc.id) in doc.__log__
-        assert doc.__db__ is db
+    for doc in documents:
+        assert not hasattr(doc, 'id')
 
-    loop.run_until_complete(test())
+    assert len(result.inserted_ids) == len(documents)
 
 
-@pytest.fixture(scope='function')
-def doc(loop, db):
+@pytest.mark.asyncio
+async def test_save_new(db):
+    doc = Doc()
+    doc.i = 13
+
+    await db.save(doc)
+
+    assert await db.db['testdocs'].count_documents({}) == 1
+    assert (await db.db['testdocs'].find_one())['i'] == 13
+    assert Save(id=doc.id) in doc.__log__
+    assert doc.__db__ is db
+
+
+@pytest.mark.asyncio
+async def test_save(db):
+    doc = Doc()
+    doc.i = 13
+    await db.save(doc)
+
+    doc.i = 14
+    await db.save(doc)
+
+    assert await db.db['testdocs'].count_documents({}) == 1
+    assert (await db.db['testdocs'].find_one())['i'] == 14
+    assert Save(id=doc.id) in doc.__log__
+    assert doc.__db__ is db
+
+
+@pytest.fixture()
+def doc(event_loop, db):
     async def fixture():
         doc = Doc(b=True, i=13, l=[1, 2, 3])
         await db.insert_one(doc)
         return doc
 
-    return loop.run_until_complete(fixture())
+    return event_loop.run_until_complete(fixture())
 
 
 @pytest.mark.parametrize('kwargs, result', [
@@ -150,133 +138,113 @@ def doc(loop, db):
         {'b': True, 'i': 666, 'l': [1, 2, 3]},
     ),
 ])
-def test_update_one(loop, db, doc, kwargs, result):
-    async def test():
-        await db.update_one(doc, **kwargs)
-        raw_doc = await db.db['testdocs'].find_one(doc.id)
+@pytest.mark.asyncio
+async def test_update_one(db, doc, kwargs, result):
+    await db.update_one(doc, **kwargs)
+    raw_doc = await db.db['testdocs'].find_one(doc.id)
 
-        assert raw_doc
-        del raw_doc['_id']
-        assert raw_doc == result
-
-    loop.run_until_complete(test())
+    assert raw_doc
+    del raw_doc['_id']
+    assert raw_doc == result
 
 
-def test_update_one__empty_query(loop, db, doc):
-    async def test():
-        assert (await db.update_one(doc)) is None
-        assert (await db.db['testdocs'].find_one(doc.id)) == to_mongo(doc)
-
-    loop.run_until_complete(test())
+@pytest.mark.asyncio
+async def test_update_one__empty_query(db, doc):
+    assert (await db.update_one(doc)) is None
+    assert (await db.db['testdocs'].find_one(doc.id)) == to_mongo(doc)
 
 
-def test_delete_one(loop, db):
-    async def test():
-        col = db.db['testdocs']
-        await col.insert_one({'i': 13})
+@pytest.mark.asyncio
+async def test_delete_one(db):
+    col = db.db['testdocs']
+    await col.insert_one({'i': 13})
 
-        doc = from_mongo(Doc, await col.find_one({'i': 13}))
+    doc = from_mongo(Doc, await col.find_one({'i': 13}))
 
-        assert await col.count_documents({}) == 1
-        await db.delete_one(doc)
-        assert await col.count_documents({}) == 0
-
-    loop.run_until_complete(test())
+    assert await col.count_documents({}) == 1
+    await db.delete_one(doc)
+    assert await col.count_documents({}) == 0
 
 
-def test_reload(loop, db):
-    async def test():
-        doc = create_fake(Doc)
-        b = doc.b
-        await db.insert_one(doc)
+@pytest.mark.asyncio
+async def test_reload(db):
+    doc = create_fake(Doc)
+    b = doc.b
+    await db.insert_one(doc)
 
-        await db.db['testdocs'].update_one({'_id': doc.id},
-                                           {'$set': {'b': not doc.b}})
+    await db.db['testdocs'].update_one({'_id': doc.id},
+                                       {'$set': {'b': not doc.b}})
 
-        assert doc.b == b
-        new_doc = await db.reload(doc)
-        assert new_doc is doc
-        assert doc.b != b
-        assert doc.i
-
-    loop.run_until_complete(test())
+    assert doc.b == b
+    new_doc = await db.reload(doc)
+    assert new_doc is doc
+    assert doc.b != b
+    assert doc.i
 
 
-def test_reload__projection(loop, db):
-    async def test():
-        doc = create_fake(Doc)
-        b = doc.b
-        await db.insert_one(doc)
+@pytest.mark.asyncio
+async def test_reload__projection(db):
+    doc = create_fake(Doc)
+    b = doc.b
+    await db.insert_one(doc)
 
-        await db.db['testdocs'].update_one({'_id': doc.id},
-                                           {'$set': {'b': not doc.b}})
+    await db.db['testdocs'].update_one({'_id': doc.id},
+                                       {'$set': {'b': not doc.b}})
 
-        assert doc.b == b
-        new_doc = await db.reload(doc, projection={'b': True})
-        assert new_doc is doc
-        assert doc.b != b
+    assert doc.b == b
+    new_doc = await db.reload(doc, projection={'b': True})
+    assert new_doc is doc
+    assert doc.b != b
+    assert 'i' in doc.__not_loaded__
+
+
+@pytest.mark.asyncio
+async def test_reload__new_instance(db):
+    doc = create_fake(Doc)
+    b = doc.b
+    await db.insert_one(doc)
+
+    await db.db['testdocs'].update_one({'_id': doc.id},
+                                       {'$set': {'b': not doc.b}})
+
+    assert doc.b == b
+    new_doc = await db.reload(doc, new_instance=True)
+    assert new_doc is not doc
+    assert doc.b == b
+    assert new_doc.b != b
+
+
+@pytest.mark.asyncio
+async def test_get_document(db):
+    documents = [Doc(i=i) for i in range(5)]
+    result = await db.db['testdocs'].insert_many((to_mongo(d) for d in documents))
+    assert len(result.inserted_ids) == len(documents)
+    for _id in result.inserted_ids:
+        doc = await db.get_document(Doc, _id)
+        assert doc.id == _id
+
+
+@pytest.mark.asyncio
+async def test_get_document__projection(db):
+    documents = [Doc(i=i) for i in range(5)]
+    result = await db.db['testdocs'].insert_many((to_mongo(d) for d in documents))
+    assert len(result.inserted_ids) == len(documents)
+    for _id in result.inserted_ids:
+        doc = await db.get_document(Doc, _id, projection={'i': False})
+        assert doc.id == _id
         assert 'i' in doc.__not_loaded__
 
-    loop.run_until_complete(test())
+
+@pytest.mark.asyncio
+async def test_get_document__not_found(db):
+    doc = await db.get_document(Doc, ObjectId())
+    assert doc is None
 
 
-def test_reload__new_instance(loop, db):
-    async def test():
-        doc = create_fake(Doc)
-        b = doc.b
-        await db.insert_one(doc)
+@pytest.mark.asyncio
+async def test_get_document__exc(db):
+    class NotFound(Exception):
+        pass
 
-        await db.db['testdocs'].update_one({'_id': doc.id},
-                                           {'$set': {'b': not doc.b}})
-
-        assert doc.b == b
-        new_doc = await db.reload(doc, new_instance=True)
-        assert new_doc is not doc
-        assert doc.b == b
-        assert new_doc.b != b
-
-    loop.run_until_complete(test())
-
-
-def test_get_document(loop, db):
-    async def test():
-        documents = [Doc(i=i) for i in range(5)]
-        result = await db.db['testdocs'].insert_many((to_mongo(d) for d in documents))
-        assert len(result.inserted_ids) == len(documents)
-        for _id in result.inserted_ids:
-            doc = await db.get_document(Doc, _id)
-            assert doc.id == _id
-
-    loop.run_until_complete(test())
-
-
-def test_get_document__projection(loop, db):
-    async def test():
-        documents = [Doc(i=i) for i in range(5)]
-        result = await db.db['testdocs'].insert_many((to_mongo(d) for d in documents))
-        assert len(result.inserted_ids) == len(documents)
-        for _id in result.inserted_ids:
-            doc = await db.get_document(Doc, _id, projection={'i': False})
-            assert doc.id == _id
-            assert 'i' in doc.__not_loaded__
-
-    loop.run_until_complete(test())
-
-
-def test_get_document__not_found(loop, db):
-    async def test():
-        doc = await db.get_document(Doc, ObjectId())
-        assert doc is None
-
-    loop.run_until_complete(test())
-
-
-def test_get_document__exc(loop, db):
-    async def test():
-        class NotFound(Exception):
-            pass
-
-        with pytest.raises(NotFound):
-            await db.get_document(Doc, ObjectId(), exc=NotFound)
-
-    loop.run_until_complete(test())
+    with pytest.raises(NotFound):
+        await db.get_document(Doc, ObjectId(), exc=NotFound)

--- a/tests/tests_aio/test_fields_reference.py
+++ b/tests/tests_aio/test_fields_reference.py
@@ -1,5 +1,6 @@
 from bson import ObjectId
 
+import pytest
 from yadm.documents import Document
 from yadm import fields
 
@@ -14,38 +15,34 @@ class Doc(Document):
     ref = fields.ReferenceField(DocRef)
 
 
-def test_get(loop, db):
-    async def test():
-        id_ref = (await db.db.testdocs_ref.insert_one({'i': 13})).inserted_id
-        id = (await db.db.testdocs.insert_one({'ref': id_ref})).inserted_id
+@pytest.mark.asyncio
+async def test_get(db):
+    id_ref = (await db.db.testdocs_ref.insert_one({'i': 13})).inserted_id
+    id = (await db.db.testdocs.insert_one({'ref': id_ref})).inserted_id
 
-        doc = await db.get_queryset(Doc).find_one(id)
+    doc = await db.get_queryset(Doc).find_one(id)
 
-        assert ' -)' in repr(doc.ref)
-        ref = await doc.ref
-        assert ' +)' in repr(doc.ref)
+    assert ' -)' in repr(doc.ref)
+    ref = await doc.ref
+    assert ' +)' in repr(doc.ref)
 
-        assert doc._id == id
-        assert isinstance(ref, Document)
-        assert ref._id == id_ref
-        assert isinstance(doc.ref, ObjectId)
-        assert ref is (await doc.ref) is (await doc.ref) is doc.ref.document
-        assert doc.ref is doc.ref
-        assert doc.__qs__.cache[(DocRef, ref.id)] is doc.ref
-
-    loop.run_until_complete(test())
+    assert doc._id == id
+    assert isinstance(ref, Document)
+    assert ref._id == id_ref
+    assert isinstance(doc.ref, ObjectId)
+    assert ref is (await doc.ref) is (await doc.ref) is doc.ref.document
+    assert doc.ref is doc.ref
+    assert doc.__qs__.cache[(DocRef, ref.id)] is doc.ref
 
 
-def test_get_reference_from_new_instance(loop, db):
-    async def test():
-        _id = (await db.db.testdocs_ref.insert_one({'i': 13})).inserted_id
-        doc_ref = await db(DocRef).find_one({'_id': _id})
+@pytest.mark.asyncio
+async def test_get_reference_from_new_instance(db):
+    _id = (await db.db.testdocs_ref.insert_one({'i': 13})).inserted_id
+    doc_ref = await db(DocRef).find_one({'_id': _id})
 
-        doc = Doc()
-        doc.ref = doc_ref
+    doc = Doc()
+    doc.ref = doc_ref
 
-        await db.insert_one(doc)
+    await db.insert_one(doc)
 
-        assert (await doc.ref).id == _id
-
-    loop.run_until_complete(test())
+    assert (await doc.ref).id == _id

--- a/tests/tests_aio/test_fields_references_list.py
+++ b/tests/tests_aio/test_fields_references_list.py
@@ -1,3 +1,4 @@
+import pytest
 from yadm.documents import Document
 from yadm import fields
 from yadm.fields.references_list import ReferencesListField, ReferencesList
@@ -13,37 +14,35 @@ class Doc(Document):
     ref = ReferencesListField(RDoc)
 
 
-def test_resolve(loop, db):
-    async def test():
-        ref_one = RDoc()
-        ref_one.i = 13
-        await db.insert_one(ref_one)
+@pytest.mark.asyncio
+async def test_resolve(db):
+    ref_one = RDoc()
+    ref_one.i = 13
+    await db.insert_one(ref_one)
 
-        ref_two = RDoc()
-        ref_two.i = 42
-        await db.insert_one(ref_two)
+    ref_two = RDoc()
+    ref_two.i = 42
+    await db.insert_one(ref_two)
 
-        ref_three = RDoc()
-        ref_three.i = 666
-        await db.insert_one(ref_three)
+    ref_three = RDoc()
+    ref_three.i = 666
+    await db.insert_one(ref_three)
 
-        doc = Doc()
-        doc.ref.extend([ref_one, ref_two])
-        await db.insert_one(doc)
+    doc = Doc()
+    doc.ref.extend([ref_one, ref_two])
+    await db.insert_one(doc)
 
-        doc = await db.get_document(Doc, doc.id)
+    doc = await db.get_document(Doc, doc.id)
 
-        assert isinstance(doc.ref, ReferencesList)
-        assert len(doc.ref) == 2
-        assert len(doc.ref.ids) == 2
-        assert len(doc.ref._documents) == 0
-        assert not doc.ref.resolved
+    assert isinstance(doc.ref, ReferencesList)
+    assert len(doc.ref) == 2
+    assert len(doc.ref.ids) == 2
+    assert len(doc.ref._documents) == 0
+    assert not doc.ref.resolved
 
-        await doc.ref.resolve()
+    await doc.ref.resolve()
 
-        assert doc.ref.resolved
-        assert len(doc.ref) == 2
-        assert len(doc.ref.ids) == 2
-        assert len(doc.ref._documents) == 2
-
-    loop.run_until_complete(test())
+    assert doc.ref.resolved
+    assert len(doc.ref) == 2
+    assert len(doc.ref.ids) == 2
+    assert len(doc.ref._documents) == 2

--- a/tests/tests_aio/test_queryset.py
+++ b/tests/tests_aio/test_queryset.py
@@ -1,7 +1,6 @@
 import random
 
 import pytest
-
 import pymongo
 from bson import ObjectId
 
@@ -17,7 +16,7 @@ class Doc(Document):
 
 
 @pytest.fixture
-def qs(loop, db):
+def qs(event_loop, db):
     async def fixture():
         for n in range(10):
             await db.db['testdocs'].insert_one({
@@ -25,21 +24,19 @@ def qs(loop, db):
                 's': 'str({})'.format(n),
             })
 
-    loop.run_until_complete(fixture())
+    event_loop.run_until_complete(fixture())
     return db.get_queryset(Doc)
 
 
-def test_aiter(loop, qs):
-    async def test():
-        n = 0
-        async for doc in qs:
-            n += 1
-            assert isinstance(doc, Doc)
-            assert isinstance(doc.id, ObjectId)
+@pytest.mark.asyncio
+async def test_aiter(qs):
+    n = 0
+    async for doc in qs:
+        n += 1
+        assert isinstance(doc, Doc)
+        assert isinstance(doc.id, ObjectId)
 
-        assert n == 10
-
-    loop.run_until_complete(test())
+    assert n == 10
 
 
 @pytest.mark.parametrize('slice, result', [
@@ -52,337 +49,288 @@ def test_aiter(loop, qs):
     (slice(-3, -1), TypeError),
     (slice(None, None, 2), TypeError),
 ])
-def test_slice(loop, qs, slice, result):
-    async def test(qs=qs):
-        if isinstance(result, type) and issubclass(result, Exception):
-            with pytest.raises(result):
-                qs = qs.find({'i': {'$gte': 6}}).sort(('i', 1))[slice]
-        else:
+@pytest.mark.asyncio
+async def test_slice(qs, slice, result):
+    if isinstance(result, type) and issubclass(result, Exception):
+        with pytest.raises(result):
             qs = qs.find({'i': {'$gte': 6}}).sort(('i', 1))[slice]
-            docs = []
-            async for doc in qs:
-                docs.append(doc)
+    else:
+        qs = qs.find({'i': {'$gte': 6}}).sort(('i', 1))[slice]
+        docs = []
+        async for doc in qs:
+            docs.append(doc)
 
-            assert [d.i for d in docs] == result
-
-    loop.run_until_complete(test())
-
-
-def test_get_one(loop, qs):
-    async def test(qs=qs):
-        qs = qs.find({'i': {'$gte': 6}}).sort(('i', 1))
-        doc = await qs[1]
-        assert doc.i == 7
-
-    loop.run_until_complete(test())
+        assert [d.i for d in docs] == result
 
 
-def test_get_one__index_error(loop, qs):
-    async def test(qs=qs):
-        qs = qs.find({'i': {'$gte': 6}}).sort(('i', 1))
-        with pytest.raises(IndexError):
-            await qs[100]
-
-    loop.run_until_complete(test())
+@pytest.mark.asyncio
+async def test_get_one(qs):
+    qs = qs.find({'i': {'$gte': 6}}).sort(('i', 1))
+    doc = await qs[1]
+    assert doc.i == 7
 
 
-def test_count_documents(loop, qs):
-    async def test(qs=qs):
-        qs = qs.find({'i': {'$gte': 6}})
-        assert await qs.count_documents() == 4
-
-    loop.run_until_complete(test())
-
-
-def test_find_one__query(loop, qs):
-    async def test():
-        doc = await qs.find_one({'i': 7})
-        assert isinstance(doc, Doc)
-        assert hasattr(doc, 'i')
-        assert doc.i == 7
-
-    loop.run_until_complete(test())
+@pytest.mark.asyncio
+async def test_get_one__index_error(qs):
+    qs = qs.find({'i': {'$gte': 6}}).sort(('i', 1))
+    with pytest.raises(IndexError):
+        await qs[100]
 
 
-def test_find_one__oid(loop, qs):
-    async def test():
-        doc = await qs[3]
-        res_doc = await qs.find_one(doc.id)
-        assert isinstance(res_doc, Doc)
-        assert res_doc.id == doc.id
-        assert res_doc.i == doc.i
-
-    loop.run_until_complete(test())
+@pytest.mark.asyncio
+async def test_count_documents(qs):
+    qs = qs.find({'i': {'$gte': 6}})
+    assert await qs.count_documents() == 4
 
 
-def test_find_one__nf(loop, qs):
-    async def test():
-        res = await qs.find_one({'i': 100500})
-        assert res is None
+@pytest.mark.asyncio
+async def test_find_one__query(qs):
+    doc = await qs.find_one({'i': 7})
+    assert isinstance(doc, Doc)
+    assert hasattr(doc, 'i')
+    assert doc.i == 7
 
-    loop.run_until_complete(test())
+
+@pytest.mark.asyncio
+async def test_find_one__oid(qs):
+    doc = await qs[3]
+    res_doc = await qs.find_one(doc.id)
+    assert isinstance(res_doc, Doc)
+    assert res_doc.id == doc.id
+    assert res_doc.i == doc.i
 
 
-def test_find_one__nf_exc(loop, qs):
+@pytest.mark.asyncio
+async def test_find_one__nf(qs):
+    res = await qs.find_one({'i': 100500})
+    assert res is None
+
+
+@pytest.mark.asyncio
+async def test_find_one__nf_exc(qs):
     class SimpleException(Exception):
         pass
-
-    async def test():
-        with pytest.raises(SimpleException):
-            await qs.find_one({'i': 100500}, exc=SimpleException)
-
-    loop.run_until_complete(test())
+    with pytest.raises(SimpleException):
+        await qs.find_one({'i': 100500}, exc=SimpleException)
 
 
-def test_update_one(loop, db, qs):
-    async def test():
-        result = await qs.find({
-            'i': {'$in': [3, 7]},
-        }).update_one({
-            '$set': {'s': 'test'}
-        })
+@pytest.mark.asyncio
+async def test_update_one(db, qs):
+    result = await qs.find({
+        'i': {'$in': [3, 7]},
+    }).update_one({
+        '$set': {'s': 'test'}
+    })
 
-        assert isinstance(result, pymongo.results.UpdateResult)
-        assert result.acknowledged
-        assert result.matched_count == result.modified_count == 1
-        assert result.upserted_id is None
+    assert isinstance(result, pymongo.results.UpdateResult)
+    assert result.acknowledged
+    assert result.matched_count == result.modified_count == 1
+    assert result.upserted_id is None
 
-        assert (await db.db['testdocs'].count_documents({})) == 10
-        assert {d['i'] async for d in db.db['testdocs'].find()} == set(range(10))
-        assert (await db.db['testdocs'].count_documents({'s': 'test'})) == 1
+    assert (await db.db['testdocs'].count_documents({})) == 10
+    assert {d['i'] async for d in db.db['testdocs'].find()} == set(range(10))
+    assert (await db.db['testdocs'].count_documents({'s': 'test'})) == 1
 
-        async for doc in db.db['testdocs'].find({'i': {'$nin': [3, 7]}}):
-            assert doc['s'] != 'test'
-            assert doc['s'].startswith('str(')
+    async for doc in db.db['testdocs'].find({'i': {'$nin': [3, 7]}}):
+        assert doc['s'] != 'test'
+        assert doc['s'].startswith('str(')
 
-        doc_3 = await db.db['testdocs'].find_one({'i': 3})
-        doc_7 = await db.db['testdocs'].find_one({'i': 7})
-        assert doc_3['s'] == 'test' or doc_7['s'] == 'test'
-        assert doc_3['s'] != 'test' or doc_7['s'] != 'test'
-
-    loop.run_until_complete(test())
+    doc_3 = await db.db['testdocs'].find_one({'i': 3})
+    doc_7 = await db.db['testdocs'].find_one({'i': 7})
+    assert doc_3['s'] == 'test' or doc_7['s'] == 'test'
+    assert doc_3['s'] != 'test' or doc_7['s'] != 'test'
 
 
-def test_update_many(loop, db, qs):
-    async def test():
-        result = await qs.find({
-            'i': {'$gte': 6}
-        }).update_many({
-            '$set': {'s': 'test'}
-        })
+@pytest.mark.asyncio
+async def test_update_many(db, qs):
+    result = await qs.find({
+        'i': {'$gte': 6}
+    }).update_many({
+        '$set': {'s': 'test'}
+    })
 
-        assert isinstance(result, pymongo.results.UpdateResult)
-        assert result.acknowledged
-        assert result.matched_count == result.modified_count == 4
-        assert result.upserted_id is None
+    assert isinstance(result, pymongo.results.UpdateResult)
+    assert result.acknowledged
+    assert result.matched_count == result.modified_count == 4
+    assert result.upserted_id is None
 
-        assert (await db.db['testdocs'].count_documents({})) == 10
-        assert {d['i'] async for d in db.db['testdocs'].find()} == set(range(10))
-        assert (await db.db['testdocs'].count_documents({'s': 'test'})) == 4
+    assert (await db.db['testdocs'].count_documents({})) == 10
+    assert {d['i'] async for d in db.db['testdocs'].find()} == set(range(10))
+    assert (await db.db['testdocs'].count_documents({'s': 'test'})) == 4
 
-        async for doc in db.db['testdocs'].find({'i': {'$lt': 6}}):
-            assert doc['s'] != 'test'
-            assert doc['s'].startswith('str(')
+    async for doc in db.db['testdocs'].find({'i': {'$lt': 6}}):
+        assert doc['s'] != 'test'
+        assert doc['s'].startswith('str(')
 
-        async for doc in db.db['testdocs'].find({'i': {'$gte': 6}}):
-            assert doc['s'] == 'test'
-
-    loop.run_until_complete(test())
+    async for doc in db.db['testdocs'].find({'i': {'$gte': 6}}):
+        assert doc['s'] == 'test'
 
 
-def test_delete_many(loop, db, qs):
-    async def test():
-        result = await qs.find({'i': {'$gte': 6}}).delete_many()
+@pytest.mark.asyncio
+async def test_delete_many(db, qs):
+    result = await qs.find({'i': {'$gte': 6}}).delete_many()
 
-        assert isinstance(result, pymongo.results.DeleteResult)
-        assert result.acknowledged
-        assert result.deleted_count == 4
+    assert isinstance(result, pymongo.results.DeleteResult)
+    assert result.acknowledged
+    assert result.deleted_count == 4
 
-        assert (await qs.count_documents()) == 6
-        assert {d.i async for d in qs} == set(range(6))
+    assert (await qs.count_documents()) == 6
+    assert {d.i async for d in qs} == set(range(6))
 
-        assert await db.db['testdocs'].count_documents({}) == 6
-        assert {d['i'] async for d in db.db['testdocs'].find()} == set(range(6))
-
-    loop.run_until_complete(test())
+    assert await db.db['testdocs'].count_documents({}) == 6
+    assert {d['i'] async for d in db.db['testdocs'].find()} == set(range(6))
 
 
-def test_delete_one(loop, db, qs):
-    async def test():
-        result = await qs.find({'i': {'$gte': 6}}).delete_one()
+@pytest.mark.asyncio
+async def test_delete_one(db, qs):
+    result = await qs.find({'i': {'$gte': 6}}).delete_one()
 
-        assert isinstance(result, pymongo.results.DeleteResult)
-        assert result.acknowledged
-        assert result.deleted_count == 1
+    assert isinstance(result, pymongo.results.DeleteResult)
+    assert result.acknowledged
+    assert result.deleted_count == 1
 
-        assert (await qs.count_documents()) == 9
+    assert (await qs.count_documents()) == 9
 
-        removed = list(set(range(10)) - {d.i async for d in qs})[0]
+    removed = list(set(range(10)) - {d.i async for d in qs})[0]
 
-        assert await db.db['testdocs'].count_documents({}) == 9
-        assert (await db.db['testdocs'].find_one({'i': removed})) is None
-
-    loop.run_until_complete(test())
+    assert await db.db['testdocs'].count_documents({}) == 9
+    assert (await db.db['testdocs'].find_one({'i': removed})) is None
 
 
 @pytest.mark.parametrize('return_document, i', [
     (pymongo.ReturnDocument.BEFORE, 9),
     (pymongo.ReturnDocument.AFTER, 99),
 ], ids=['BEFORE', 'AFTER'])
-def test_find_one_and_update(loop, db, qs, return_document, i):
-    async def test(qs=qs):
-        qs = qs.find({'i': {'$gte': 5}}).sort(('i', -1))
-        doc = await qs.find_one_and_update({'$set': {'i': 99}},
-                                           return_document=return_document)
-        assert doc.i == i
-
-    loop.run_until_complete(test())
+@pytest.mark.asyncio
+async def test_find_one_and_update(db, qs, return_document, i):
+    qs = qs.find({'i': {'$gte': 5}}).sort(('i', -1))
+    doc = await qs.find_one_and_update({'$set': {'i': 99}},
+                                       return_document=return_document)
+    assert doc.i == i
 
 
 @pytest.mark.parametrize('return_document, i', [
     (pymongo.ReturnDocument.BEFORE, 9),
     (pymongo.ReturnDocument.AFTER, 99),
 ], ids=['BEFORE', 'AFTER'])
-def test_find_one_and_replace(loop, db, qs, return_document, i):
-    async def test(qs=qs):
-        qs = qs.find({'i': {'$gte': 5}}).sort(('i', -1))
-        doc = await qs.find_one_and_replace(Doc(i=99),
-                                            return_document=return_document)
-        assert doc.i == i
-
-    loop.run_until_complete(test())
+@pytest.mark.asyncio
+async def test_find_one_and_replace(db, qs, return_document, i):
+    qs = qs.find({'i': {'$gte': 5}}).sort(('i', -1))
+    doc = await qs.find_one_and_replace(Doc(i=99),
+                                        return_document=return_document)
+    assert doc.i == i
 
 
-def test_find_one_and_delete(loop, db, qs):
-    async def test(qs=qs):
-        qs = qs.find({'i': {'$gte': 5}}).sort(('i', -1))
-        doc = await qs.find_one_and_delete()
-        assert doc.i == 9
-
-    loop.run_until_complete(test())
+@pytest.mark.asyncio
+async def test_find_one_and_delete(db, qs):
+    qs = qs.find({'i': {'$gte': 5}}).sort(('i', -1))
+    doc = await qs.find_one_and_delete()
+    assert doc.i == 9
 
 
-def test_hint(loop, db, qs):
-    async def test(qs=qs):
-        await db.db[Doc.__collection__].create_index([('i', -1)])
-        await db.db[Doc.__collection__].create_index([('s', 1)])
+@pytest.mark.asyncio
+async def test_hint(db, qs):
+    await db.db[Doc.__collection__].create_index([('i', -1)])
+    await db.db[Doc.__collection__].create_index([('s', 1)])
 
-        _qs = qs.hint([('i', -1)])
+    _qs = qs.hint([('i', -1)])
+    async for doc in _qs:
+        assert doc
+
+    _qs = qs.hint([('s', 1)])
+    assert await _qs.count_documents()
+
+    _qs = qs.hint([('wrong', 1)])
+    with pytest.raises(pymongo.errors.OperationFailure):
         async for doc in _qs:
-            assert doc
+            assert False
 
-        _qs = qs.hint([('s', 1)])
-        assert await _qs.count_documents()
-
-        _qs = qs.hint([('wrong', 1)])
-        with pytest.raises(pymongo.errors.OperationFailure):
-            async for doc in _qs:
-                assert False
-
-        _qs = qs.hint([('wrong', 1)])
-        with pytest.raises(pymongo.errors.OperationFailure):
-            await _qs.count_documents()
-
-    loop.run_until_complete(test())
+    _qs = qs.hint([('wrong', 1)])
+    with pytest.raises(pymongo.errors.OperationFailure):
+        await _qs.count_documents()
 
 
-def test_distinct(loop, db, qs):
-    async def test():
-        res = await qs.distinct('i')
-        assert isinstance(res, list)
-        assert len(res) == len(set(res))
+@pytest.mark.asyncio
+async def test_distinct(db, qs):
+    res = await qs.distinct('i')
+    assert isinstance(res, list)
+    assert len(res) == len(set(res))
 
-        await db.insert_one(Doc(i=3))
-        await db.insert_one(Doc(i=4))
-        await db.insert_one(Doc(i=10))
+    await db.insert_one(Doc(i=3))
+    await db.insert_one(Doc(i=4))
+    await db.insert_one(Doc(i=10))
 
-        res = await qs.distinct('i')
-        assert len(res) == len(set(res))
-
-    loop.run_until_complete(test())
+    res = await qs.distinct('i')
+    assert len(res) == len(set(res))
 
 
-def test_ids(loop, qs):
-    async def test():
-        res = [i async for i in qs.ids()]
-        assert len(res) == 10
-        for i in res:
-            assert isinstance(i, ObjectId)
-
-    loop.run_until_complete(test())
+@pytest.mark.asyncio
+async def test_ids(qs):
+    res = [i async for i in qs.ids()]
+    assert len(res) == 10
+    for i in res:
+        assert isinstance(i, ObjectId)
 
 
-def test_bulk(loop, qs):
-    async def test():
-        bulk = await qs.find({'i': {'$gte': 6}}).bulk()
-        assert isinstance(bulk, dict)
-        assert len(bulk), 4
-        assert isinstance(list(bulk)[0], ObjectId)
-        assert isinstance(list(bulk.values())[0], Doc)
-        _id = list(bulk)[0]
-        assert bulk[_id].id == _id
-        assert {d.i for d in bulk.values()} == {6, 7, 8, 9}
-
-    loop.run_until_complete(test())
+@pytest.mark.asyncio
+async def test_bulk(qs):
+    bulk = await qs.find({'i': {'$gte': 6}}).bulk()
+    assert isinstance(bulk, dict)
+    assert len(bulk), 4
+    assert isinstance(list(bulk)[0], ObjectId)
+    assert isinstance(list(bulk.values())[0], Doc)
+    _id = list(bulk)[0]
+    assert bulk[_id].id == _id
+    assert {d.i for d in bulk.values()} == {6, 7, 8, 9}
 
 
 class TestFindIn:
     @pytest.fixture(autouse=True)
-    def ids(self, loop, qs):
+    def ids(self, event_loop, qs):
         async def fixture():
             ids = [doc.id async for doc in qs]
             random.shuffle(ids)
             return ids
 
-        return loop.run_until_complete(fixture())
+        return event_loop.run_until_complete(fixture())
 
-    def test_simple(self, loop, qs, ids):
-        async def test():
-            result = [getattr(doc, 'id', doc)
-                      async for doc in qs.find_in(ids)]
+    @pytest.mark.asyncio
+    async def test_simple(self, qs, ids):
+        result = [getattr(doc, 'id', doc)
+                  async for doc in qs.find_in(ids)]
 
-            assert result == ids
+        assert result == ids
 
-        loop.run_until_complete(test())
+    @pytest.mark.asyncio
+    async def test_skip(self, qs, ids):
+        ids.append('NotExistId')
+        result = [doc.id async for doc in qs.find_in(ids)]
+        assert result == ids[:-1]
 
-    def test_skip(self, loop, qs, ids):
-        async def test():
+    @pytest.mark.asyncio
+    async def test_none(self, qs, ids):
+        index = random.randrange(len(ids))
+        ids[index] = 'NotExistId'
+        result = [getattr(doc, 'id', doc)
+                  async for doc in qs.find_in(ids, not_found='none')]
+
+        ids[index] = None
+        assert result == ids
+
+    @pytest.mark.asyncio
+    async def test_exception(self, qs, ids):
+        [getattr(doc, 'id', doc)
+            async for doc in qs.find_in(ids, not_found='error')]
+
+        with pytest.raises(NotFoundError):
             ids.append('NotExistId')
-            result = [doc.id async for doc in qs.find_in(ids)]
-            assert result == ids[:-1]
-
-        loop.run_until_complete(test())
-
-    def test_none(self, loop, qs, ids):
-        async def test():
-            index = random.randrange(len(ids))
-            ids[index] = 'NotExistId'
-            result = [getattr(doc, 'id', doc)
-                      async for doc in qs.find_in(ids, not_found='none')]
-
-            ids[index] = None
-            assert result == ids
-
-        loop.run_until_complete(test())
-
-    def test_exception(self, loop, qs, ids):
-        async def test():
             [getattr(doc, 'id', doc)
-             async for doc in qs.find_in(ids, not_found='error')]
+                async for doc in qs.find_in(ids, not_found='error')]
 
-            with pytest.raises(NotFoundError):
-                ids.append('NotExistId')
-                [getattr(doc, 'id', doc)
-                 async for doc in qs.find_in(ids, not_found='error')]
+    @pytest.mark.asyncio
+    async def test_copy_id(self, qs, ids):
+        ids.append(ids[0])
+        result = [getattr(doc, 'id', doc)
+                  async for doc in qs.find_in(ids)]
 
-        loop.run_until_complete(test())
-
-    def test_copy_id(self, loop, qs, ids):
-        async def test():
-            ids.append(ids[0])
-            result = [getattr(doc, 'id', doc)
-                      async for doc in qs.find_in(ids)]
-
-            assert result == ids
-
-        loop.run_until_complete(test())
+        assert result == ids

--- a/tests/tests_aio/test_testing.py
+++ b/tests/tests_aio/test_testing.py
@@ -1,0 +1,213 @@
+from bson import ObjectId
+
+from yadm.documents import Document, EmbeddedDocument
+from yadm.markers import AttributeNotSet
+from yadm.aio.testing import aio_create_fake as create_fake
+from yadm.fields import (
+    BooleanField, StringField, IntegerField, ObjectIdField, EmailField,
+    EmbeddedDocumentField, ReferenceField,
+)
+
+
+class SimpleDoc(Document):
+    __collection__ = 'testdocs'
+
+    oid = ObjectIdField()
+    b = BooleanField()
+    s = StringField()
+    i = IntegerField()
+    e = EmailField()
+    email = StringField()
+    not_set = StringField()
+
+    def __fake__email__(self, faker, depth):
+        return faker.email()
+
+    def __fake__not_set__(self, faker, depth):
+        return AttributeNotSet
+
+
+class EmbeddedDoc(EmbeddedDocument):
+    __collection__ = 'testdocs'
+
+    name = StringField()
+
+
+def test_simple(loop, db):
+    async def test():
+        doc = await create_fake(SimpleDoc)
+
+        assert doc.__db__ is None
+
+        assert hasattr(doc, 'oid')
+        assert hasattr(doc, 'b')
+        assert hasattr(doc, 's')
+        assert hasattr(doc, 'i')
+        assert hasattr(doc, 'e')
+        assert hasattr(doc, 'email')
+        assert not hasattr(doc, 'not_set')
+
+        assert isinstance(doc.oid, ObjectId)
+        assert isinstance(doc.b, bool)
+        assert isinstance(doc.s, str)
+        assert isinstance(doc.i, int)
+        assert isinstance(doc.e, str)
+        assert isinstance(doc.email, str)
+
+        assert len(doc.s) > 0
+        assert '@' in doc.e
+        assert '@' in doc.email
+
+        assert await db(SimpleDoc).count_documents() == 0
+
+    loop.run_until_complete(test())
+
+
+def test_simple_save(loop, db):
+    async def test():
+        doc = await create_fake(SimpleDoc, __db__=db)
+
+        assert doc.__db__ is db
+
+        assert hasattr(doc, 'oid')
+        assert hasattr(doc, 'b')
+        assert hasattr(doc, 's')
+        assert hasattr(doc, 'i')
+        assert not hasattr(doc, 'not_set')
+
+        assert isinstance(doc.oid, ObjectId)
+        assert isinstance(doc.b, bool)
+        assert isinstance(doc.s, str)
+        assert isinstance(doc.i, int)
+
+        assert len(doc.s) > 0
+
+        assert await db(SimpleDoc).count_documents() == 1
+        assert await db(SimpleDoc).find_one(doc.id)
+
+    loop.run_until_complete(test())
+
+
+class WithEmbeddedDoc(Document):
+    __collection__ = 'testdocs'
+
+    emb = EmbeddedDocumentField(EmbeddedDoc)
+
+
+def test_embedded(loop, db):
+    async def test():
+        doc = await create_fake(WithEmbeddedDoc)
+
+        assert hasattr(doc, 'emb')
+        assert isinstance(doc.emb, EmbeddedDoc)
+        assert isinstance(doc.emb.name, str)
+
+    loop.run_until_complete(test())
+
+
+def test_embedded_depth_limit(loop, db):
+    async def test():
+        doc = await create_fake(WithEmbeddedDoc, __depth__=0)
+
+        assert hasattr(doc, 'emb')
+        assert not hasattr(doc.emb, 'name')
+
+    loop.run_until_complete(test())
+
+
+class WithReferenceDoc(Document):
+    __collection__ = 'with_ref_testdocs'
+
+    ref = ReferenceField('tests.test_testing.SimpleDoc')
+
+
+def test_reference(loop, db):
+    async def test():
+        doc = await create_fake(WithReferenceDoc)
+
+        assert hasattr(doc, 'ref')
+        assert hasattr(doc.ref, 's')
+        assert isinstance(doc.ref.s, str)
+
+        assert await db(WithReferenceDoc).count_documents() == 0
+        assert await db(SimpleDoc).count_documents() == 0
+
+    loop.run_until_complete(test())
+
+
+def test_reference_save(loop, db):
+    async def test():
+        doc = await create_fake(WithReferenceDoc, __db__=db)
+
+        assert hasattr(doc, 'ref')
+        assert hasattr(await doc.ref, 's')
+        assert isinstance((await doc.ref).s, str)
+
+        assert await db(WithReferenceDoc).count_documents() == 1
+        assert await db(SimpleDoc).count_documents() == 1
+
+    loop.run_until_complete(test())
+
+
+class WithReferenceCircleDoc(Document):
+    __collection__ = 'testdocs'
+
+    self = ReferenceField('tests.test_testing.WithReferenceCircleDoc')
+
+
+def test_reference_circle(loop, db):
+    async def test():
+        doc = await create_fake(WithReferenceCircleDoc, __db__=db, __depth__=2)
+
+        assert await db(WithReferenceCircleDoc).count_documents() == 3
+
+        assert hasattr(doc, 'self')
+        assert hasattr(await doc.self, 'self')
+        assert not hasattr(await (await doc.self).self, 'self')
+
+    loop.run_until_complete(test())
+
+
+def test_complex_fake_generator(loop, db):
+    async def test():
+        class Doc(Document):
+            i = IntegerField()
+            s = StringField()
+
+            def __fake__(self, values, faker, depth):
+                assert values['i'] == 13
+                assert 's' not in values
+                new_values = values.copy()
+                new_values['i'] += 1
+                yield new_values
+                self.s = 'string'
+                yield
+
+        doc = await create_fake(Doc, i=13)
+
+        assert doc.i == 14
+        assert doc.s == 'string'
+
+    loop.run_until_complete(test())
+
+
+def test_complex_fake_dict(loop, db):
+    async def test():
+        class Doc(Document):
+            i = IntegerField()
+            s = StringField()
+
+            def __fake__(self, values, faker, depth):
+                assert values['i'] == 13
+                assert 's' not in values
+                new_values = values.copy()
+                new_values['i'] += 1
+                new_values['s'] = 'string'
+                return new_values
+
+        doc = await create_fake(Doc, i=13)
+
+        assert doc.i == 14
+        assert doc.s == 'string'
+
+    loop.run_until_complete(test())

--- a/tests/tests_aio/test_testing.py
+++ b/tests/tests_aio/test_testing.py
@@ -1,3 +1,4 @@
+import pytest
 from bson import ObjectId
 
 from yadm.documents import Document, EmbeddedDocument
@@ -33,59 +34,55 @@ class EmbeddedDoc(EmbeddedDocument):
     name = StringField()
 
 
-def test_simple(loop, db):
-    async def test():
-        doc = await create_fake(SimpleDoc)
+@pytest.mark.asyncio()
+async def test_simple(db):
+    doc = await create_fake(SimpleDoc)
 
-        assert doc.__db__ is None
+    assert doc.__db__ is None
 
-        assert hasattr(doc, 'oid')
-        assert hasattr(doc, 'b')
-        assert hasattr(doc, 's')
-        assert hasattr(doc, 'i')
-        assert hasattr(doc, 'e')
-        assert hasattr(doc, 'email')
-        assert not hasattr(doc, 'not_set')
+    assert hasattr(doc, 'oid')
+    assert hasattr(doc, 'b')
+    assert hasattr(doc, 's')
+    assert hasattr(doc, 'i')
+    assert hasattr(doc, 'e')
+    assert hasattr(doc, 'email')
+    assert not hasattr(doc, 'not_set')
 
-        assert isinstance(doc.oid, ObjectId)
-        assert isinstance(doc.b, bool)
-        assert isinstance(doc.s, str)
-        assert isinstance(doc.i, int)
-        assert isinstance(doc.e, str)
-        assert isinstance(doc.email, str)
+    assert isinstance(doc.oid, ObjectId)
+    assert isinstance(doc.b, bool)
+    assert isinstance(doc.s, str)
+    assert isinstance(doc.i, int)
+    assert isinstance(doc.e, str)
+    assert isinstance(doc.email, str)
 
-        assert len(doc.s) > 0
-        assert '@' in doc.e
-        assert '@' in doc.email
+    assert len(doc.s) > 0
+    assert '@' in doc.e
+    assert '@' in doc.email
 
-        assert await db(SimpleDoc).count_documents() == 0
-
-    loop.run_until_complete(test())
+    assert await db(SimpleDoc).count_documents() == 0
 
 
-def test_simple_save(loop, db):
-    async def test():
-        doc = await create_fake(SimpleDoc, __db__=db)
+@pytest.mark.asyncio()
+async def test_simple_save(db):
+    doc = await create_fake(SimpleDoc, __db__=db)
 
-        assert doc.__db__ is db
+    assert doc.__db__ is db
 
-        assert hasattr(doc, 'oid')
-        assert hasattr(doc, 'b')
-        assert hasattr(doc, 's')
-        assert hasattr(doc, 'i')
-        assert not hasattr(doc, 'not_set')
+    assert hasattr(doc, 'oid')
+    assert hasattr(doc, 'b')
+    assert hasattr(doc, 's')
+    assert hasattr(doc, 'i')
+    assert not hasattr(doc, 'not_set')
 
-        assert isinstance(doc.oid, ObjectId)
-        assert isinstance(doc.b, bool)
-        assert isinstance(doc.s, str)
-        assert isinstance(doc.i, int)
+    assert isinstance(doc.oid, ObjectId)
+    assert isinstance(doc.b, bool)
+    assert isinstance(doc.s, str)
+    assert isinstance(doc.i, int)
 
-        assert len(doc.s) > 0
+    assert len(doc.s) > 0
 
-        assert await db(SimpleDoc).count_documents() == 1
-        assert await db(SimpleDoc).find_one(doc.id)
-
-    loop.run_until_complete(test())
+    assert await db(SimpleDoc).count_documents() == 1
+    assert await db(SimpleDoc).find_one(doc.id)
 
 
 class WithEmbeddedDoc(Document):
@@ -94,25 +91,21 @@ class WithEmbeddedDoc(Document):
     emb = EmbeddedDocumentField(EmbeddedDoc)
 
 
-def test_embedded(loop, db):
-    async def test():
-        doc = await create_fake(WithEmbeddedDoc)
+@pytest.mark.asyncio()
+async def test_embedded():
+    doc = await create_fake(WithEmbeddedDoc)
 
-        assert hasattr(doc, 'emb')
-        assert isinstance(doc.emb, EmbeddedDoc)
-        assert isinstance(doc.emb.name, str)
-
-    loop.run_until_complete(test())
+    assert hasattr(doc, 'emb')
+    assert isinstance(doc.emb, EmbeddedDoc)
+    assert isinstance(doc.emb.name, str)
 
 
-def test_embedded_depth_limit(loop, db):
-    async def test():
-        doc = await create_fake(WithEmbeddedDoc, __depth__=0)
+@pytest.mark.asyncio()
+async def test_embedded_depth_limit():
+    doc = await create_fake(WithEmbeddedDoc, __depth__=0)
 
-        assert hasattr(doc, 'emb')
-        assert not hasattr(doc.emb, 'name')
-
-    loop.run_until_complete(test())
+    assert hasattr(doc, 'emb')
+    assert not hasattr(doc.emb, 'name')
 
 
 class WithReferenceDoc(Document):
@@ -121,32 +114,28 @@ class WithReferenceDoc(Document):
     ref = ReferenceField('tests.test_testing.SimpleDoc')
 
 
-def test_reference(loop, db):
-    async def test():
-        doc = await create_fake(WithReferenceDoc)
+@pytest.mark.asyncio()
+async def test_reference(db):
+    doc = await create_fake(WithReferenceDoc)
 
-        assert hasattr(doc, 'ref')
-        assert hasattr(doc.ref, 's')
-        assert isinstance(doc.ref.s, str)
+    assert hasattr(doc, 'ref')
+    assert hasattr(doc.ref, 's')
+    assert isinstance(doc.ref.s, str)
 
-        assert await db(WithReferenceDoc).count_documents() == 0
-        assert await db(SimpleDoc).count_documents() == 0
-
-    loop.run_until_complete(test())
+    assert await db(WithReferenceDoc).count_documents() == 0
+    assert await db(SimpleDoc).count_documents() == 0
 
 
-def test_reference_save(loop, db):
-    async def test():
-        doc = await create_fake(WithReferenceDoc, __db__=db)
+@pytest.mark.asyncio()
+async def test_reference_save(db):
+    doc = await create_fake(WithReferenceDoc, __db__=db)
 
-        assert hasattr(doc, 'ref')
-        assert hasattr(await doc.ref, 's')
-        assert isinstance((await doc.ref).s, str)
+    assert hasattr(doc, 'ref')
+    assert hasattr(await doc.ref, 's')
+    assert isinstance((await doc.ref).s, str)
 
-        assert await db(WithReferenceDoc).count_documents() == 1
-        assert await db(SimpleDoc).count_documents() == 1
-
-    loop.run_until_complete(test())
+    assert await db(WithReferenceDoc).count_documents() == 1
+    assert await db(SimpleDoc).count_documents() == 1
 
 
 class WithReferenceCircleDoc(Document):
@@ -155,59 +144,53 @@ class WithReferenceCircleDoc(Document):
     self = ReferenceField('tests.test_testing.WithReferenceCircleDoc')
 
 
-def test_reference_circle(loop, db):
-    async def test():
-        doc = await create_fake(WithReferenceCircleDoc, __db__=db, __depth__=2)
+@pytest.mark.asyncio()
+async def test_reference_circle(db):
+    doc = await create_fake(WithReferenceCircleDoc, __db__=db, __depth__=2)
 
-        assert await db(WithReferenceCircleDoc).count_documents() == 3
+    assert await db(WithReferenceCircleDoc).count_documents() == 3
 
-        assert hasattr(doc, 'self')
-        assert hasattr(await doc.self, 'self')
-        assert not hasattr(await (await doc.self).self, 'self')
-
-    loop.run_until_complete(test())
+    assert hasattr(doc, 'self')
+    assert hasattr(await doc.self, 'self')
+    assert not hasattr(await (await doc.self).self, 'self')
 
 
-def test_complex_fake_generator(loop, db):
-    async def test():
-        class Doc(Document):
-            i = IntegerField()
-            s = StringField()
+@pytest.mark.asyncio()
+async def test_complex_fake_generator():
+    class Doc(Document):
+        i = IntegerField()
+        s = StringField()
 
-            def __fake__(self, values, faker, depth):
-                assert values['i'] == 13
-                assert 's' not in values
-                new_values = values.copy()
-                new_values['i'] += 1
-                yield new_values
-                self.s = 'string'
-                yield
+        def __fake__(self, values, faker, depth):
+            assert values['i'] == 13
+            assert 's' not in values
+            new_values = values.copy()
+            new_values['i'] += 1
+            yield new_values
+            self.s = 'string'
+            yield
 
-        doc = await create_fake(Doc, i=13)
+    doc = await create_fake(Doc, i=13)
 
-        assert doc.i == 14
-        assert doc.s == 'string'
-
-    loop.run_until_complete(test())
+    assert doc.i == 14
+    assert doc.s == 'string'
 
 
-def test_complex_fake_dict(loop, db):
-    async def test():
-        class Doc(Document):
-            i = IntegerField()
-            s = StringField()
+@pytest.mark.asyncio()
+async def test_complex_fake_dict():
+    class Doc(Document):
+        i = IntegerField()
+        s = StringField()
 
-            def __fake__(self, values, faker, depth):
-                assert values['i'] == 13
-                assert 's' not in values
-                new_values = values.copy()
-                new_values['i'] += 1
-                new_values['s'] = 'string'
-                return new_values
+        def __fake__(self, values, faker, depth):
+            assert values['i'] == 13
+            assert 's' not in values
+            new_values = values.copy()
+            new_values['i'] += 1
+            new_values['s'] = 'string'
+            return new_values
 
-        doc = await create_fake(Doc, i=13)
+    doc = await create_fake(Doc, i=13)
 
-        assert doc.i == 14
-        assert doc.s == 'string'
-
-    loop.run_until_complete(test())
+    assert doc.i == 14
+    assert doc.s == 'string'

--- a/yadm/aio/testing.py
+++ b/yadm/aio/testing.py
@@ -1,0 +1,95 @@
+from collections import Counter
+from types import GeneratorType, CoroutineType
+
+import pymongo
+from faker import Faker
+
+from yadm.documents import BaseDocument, Document, EmbeddedDocument
+from yadm.markers import AttributeNotSet
+from yadm.testing import DEFAULT_DEPTH
+
+
+async def aio_create_fake(__document_class__,
+                          __db__=None,
+                          __faker__=None,
+                          *,
+                          __parent__=None,
+                          __name__=None,
+                          __depth__=DEFAULT_DEPTH,
+                          __write_concern__=pymongo.WriteConcern(w='majority'),
+                          **values):
+    if not issubclass(__document_class__, BaseDocument):  # pragma: no cover
+        raise TypeError("only BaseDocument subclasses is allowed")
+
+    aio_create_fake.counter[__document_class__] += 1
+
+    if __depth__ < 0:
+        return AttributeNotSet
+
+    if __faker__ is None:
+        aio_create_fake.counter['__without_faker__'] += 1
+        __faker__ = Faker()
+
+    document = __document_class__()
+
+    if isinstance(document, Document):
+        document.__db__ = __db__
+    elif isinstance(document, EmbeddedDocument):
+        document.__parent__ = __parent__
+        document.__name__ = __name__
+
+    doc_fake_proc = document.__fake__(values, __faker__, __depth__ - 1)
+
+    # extend values from __fake__ method
+    if isinstance(doc_fake_proc, GeneratorType):
+        values = next(doc_fake_proc)
+    elif isinstance(doc_fake_proc, dict):
+        values = doc_fake_proc
+
+    # first: set values
+    for name, fake in values.items():
+        if fake is not AttributeNotSet:
+            setattr(document, name, fake)
+
+    # second: field faker
+    for name, field in __document_class__.__fields__.items():
+        if name not in values and not hasattr(document, '__fake__{}__'.format(name)):
+            fake = field.get_fake(document, __faker__, __depth__ - 1)
+
+            if isinstance(fake, CoroutineType):
+                fake = await fake
+            if fake is not AttributeNotSet:
+                setattr(document, name, fake)
+
+    # third: __fake__{name}__ methods
+    for name, field in __document_class__.__fields__.items():
+        if name not in values and hasattr(document, '__fake__{}__'.format(name)):
+            attr = getattr(document, '__fake__{}__'.format(name))
+            fake = attr(__faker__, __depth__ - 1)
+            if isinstance(fake, CoroutineType):
+                fake = await fake
+
+            if fake is not AttributeNotSet:
+                setattr(document, name, fake)
+
+    if isinstance(doc_fake_proc, GeneratorType):
+        # pre save processor
+        try:
+            next(doc_fake_proc)
+        except StopIteration:
+            doc_fake_proc = None
+
+    if __db__ is not None:
+        await __db__.insert_one(document, write_concern=__write_concern__)
+
+        # post save processor
+        if isinstance(doc_fake_proc, GeneratorType):
+            try:
+                next(doc_fake_proc)
+            except StopIteration:
+                pass
+
+    return document
+
+
+aio_create_fake.counter = Counter()


### PR DESCRIPTION
This PR is occured because i found a problem with testing in one of project based on aiohttp. The problem is that original create_fake function do not create objects folowing by ReferenceFields. This is because it not prepare for using with asyncio.
The solution in this PR is a new function aio_create_fake which generally repeat original body function, but ready for work in asyncio.
This PR consist of two parts by commits
1) the new function, fixes in code
2) do aio test via pytest plugin `pytest-asyncio`. It reduce code in test and make it nice

Also i research to add faker fixture and use it in tests for speed up. But a real usage of create_fake in tests is less and as result theres no essentialy speed up. 