### PR TITLE
Fix EnumStateField for usage in Document subclasses inheritance.

### DIFF
--- a/tests/test_fields_enum.py
+++ b/tests/test_fields_enum.py
@@ -96,3 +96,9 @@ class TestEnumStateField:
     def test_initial_value__raises(self):
         with pytest.raises(EnumStateInvalidInitial):
             doc = self.Doc(e=WordsEnum.b)
+
+    def test_derive(self):
+        class Derived(self.__class__.Doc):
+            pass
+        doc = Derived()
+        assert doc.e == WordsEnum.a

--- a/yadm/fields/enum.py
+++ b/yadm/fields/enum.py
@@ -44,7 +44,10 @@ class EnumStateField(EnumField):
     rules = None
 
     def __init__(self, enum, rules=None, start=AttributeNotSet, **kwargs):
-        super().__init__(enum, default=start, **kwargs)
+        if 'default' not in kwargs:
+            kwargs = {'default': start, **kwargs}
+
+        super().__init__(enum, **kwargs)
 
         if rules is not None:
             self.rules = rules


### PR DESCRIPTION
Attempt to derive a Document that contains an EnumStateField causes an error on calling EnumStateField.copy()
```
  File ".../yadm/documents.py", line 40, in __init__
    cls_dict[name] = field.copy()
                     ^^^^^^^^^^^^
  File ".../yadm/fields/enum.py", line 57, in copy
    return self.__class__(self.type, self.rules,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../yadm/fields/enum.py", line 47, in __init__
    super().__init__(enum, default=start, **kwargs)
TypeError: yadm.fields.enum.EnumField.__init__() got multiple values for keyword argument 'default'
```
The PR offers a fix for this.